### PR TITLE
[fix] 4-connection-restart-method-and-button-should-be-added

### DIFF
--- a/Project001/main.cpp
+++ b/Project001/main.cpp
@@ -14,18 +14,19 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
     QGuiApplication app(argc, argv);
-    Dashboard mydashboard;
-    qmlRegisterType<Dashboard>("Dashboardqml", 1, 0, "Dashboard");
     QQmlApplicationEngine engine;
-
+    Dashboard mydashboard;
     TcpClient *client = new TcpClient("192.168.0.10", (quint16)35000);
     QThread clientThread;
+    TcpClientWrapper *clientWrapper = new TcpClientWrapper(client);
+
+    qmlRegisterType<Dashboard>("Dashboardqml", 1, 0, "Dashboard");
+
     client->moveToThread(&clientThread);
     QObject::connect(&clientThread, &QThread::started, client, &TcpClient::connectToServer);
     QObject::connect(&clientThread, &QThread::finished, client, &QObject::deleteLater);
     QObject::connect(&app, &QCoreApplication::aboutToQuit, &clientThread, &QThread::quit);
-
-    TcpClientWrapper *clientWrapper = new TcpClientWrapper(client);
+    QObject::connect(clientWrapper, &TcpClientWrapper::resetSignal,client, &TcpClient::handleResetSignal);
 
     clientThread.start();
 

--- a/Project001/main.qml
+++ b/Project001/main.qml
@@ -3,7 +3,6 @@ import QtQuick.Window 2.15
 import Dashboardqml 1.0
 import QtQuick.Timeline 1.0
 
-
 Window {
     visible: true
     width: 1024
@@ -71,6 +70,25 @@ Window {
             anchors.fill: parent
             onClicked: {
                 Qt.quit()
+            }
+        }
+    }
+
+    Rectangle {
+        x : 919
+        y : 580
+        width: 50
+        height : 20
+        Text {
+            id: reset
+            text: qsTr("reset")
+        }
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                //Reset command should send here
+                console.log("Clicked")
+                tcpClient.resetSignal()
             }
         }
     }

--- a/Project001/tcpclient.cpp
+++ b/Project001/tcpclient.cpp
@@ -12,6 +12,7 @@ TcpClient::TcpClient(const QString& ip, quint16 port, QObject* parent)
     m_ThrottlePosStruct(std::make_shared<Datapoint>())
 {
 
+
     m_counter = 0;
     tcpSocket = new QTcpSocket(this);
 
@@ -40,8 +41,12 @@ void TcpClient::connectToServer() {
     }
     qDebug() << "Connected to the server!";
     // Setup OBD-II communication
-    writeData("AT E0\rAT L0\rAT H0\rAT S1\rAT AT1\r");
+    configureOBDII();
     sendTimer->start(SENDING_PERIOD);
+}
+
+void TcpClient::configureOBDII(){
+    writeData("AT E0\rAT L0\rAT H0\rAT S1\rAT AT1\r");
 }
 
 void TcpClient::onConnected(){
@@ -187,4 +192,13 @@ void TcpClient::processMessage(const QByteArray& message) {
             emit rpmSent(m_counter);
         }
     }
+}
+
+void TcpClient::handleResetSignal(){
+    qDebug() << "Reset signal is triggered";
+    writeData("ATZ\r");
+    sendTimer->stop();
+    QThread::sleep(5);
+    configureOBDII();
+    sendTimer->start();
 }

--- a/Project001/tcpclient.h
+++ b/Project001/tcpclient.h
@@ -26,11 +26,13 @@
 #include <QDateTime>
 #include <memory>
 #include <cmath>
+#include <QThread>
 
 class TcpClient : public QObject {
      const int SENDING_PERIOD = 200;
 
     Q_OBJECT
+
 
 public:
     explicit TcpClient(const QString& ip, quint16 port, QObject* parent = nullptr);
@@ -50,6 +52,7 @@ private slots:
     void onSendData();
 
 public slots:
+    void handleResetSignal();
 
 signals:
     void    engineLoadSent(const qreal &_engineload);
@@ -73,8 +76,10 @@ private:
     //QStringList datas{"0104\r","010C\r","010D\r","0110\r"};
 
     std::chrono::high_resolution_clock::time_point prevtime;
-    void writeData(const QString& data);
+
     void processMessage(const QByteArray& message);
+    void writeData(const QString& data);
+    void configureOBDII();
     qreal m_counter;
 
     std::shared_ptr<Datapoint> m_EngineLoadStruct;

--- a/Project001/tcpclientwrapper.cpp
+++ b/Project001/tcpclientwrapper.cpp
@@ -161,3 +161,4 @@ void TcpClientWrapper::mafReceived(const qreal &_maf){
 void TcpClientWrapper::throttlePosReceived(const qreal &_throttlepos){
     setThrottlePos(_throttlepos);
 }
+

--- a/Project001/tcpclientwrapper.h
+++ b/Project001/tcpclientwrapper.h
@@ -44,6 +44,7 @@ signals:
     void    intakeTempChanged();
     void    mafChanged();
     void    throttlePosChanged();
+    void    resetSignal();
 
 public slots:
     void    engineLoadReceived(const qreal &_engineload);


### PR DESCRIPTION
1-)  Connection reset context added to main.qml
2-)  Signal slot mechanism added in between tcpclientwrapper and tcpclient.
3-)  configureOBDII function added to configure obd2 device after resetting.